### PR TITLE
Add TrialsController and related DTOs for GET trial templates API

### DIFF
--- a/GoBetGoal_BackEnd/Controllers/TrialsController.cs
+++ b/GoBetGoal_BackEnd/Controllers/TrialsController.cs
@@ -1,0 +1,82 @@
+﻿using GoBetGoal_BackEnd.Models;
+using GoBetGoal_BackEnd.Models.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Data.Entity;
+
+namespace GoBetGoal_BackEnd.Controllers
+{
+    public class TrialsController : BaseApiController
+    {
+        private readonly Context _context = new Context();
+
+        [AllowAnonymous]
+        [HttpGet]
+        [Route("api/trials/templates")]
+        public IHttpActionResult GetAllTrialTemplates()
+        {
+            // 先把資料庫資料撈出來 (包含關卡 Stages)
+            var templates = _context.TrialTemplates.Include(t => t.Stages).ToList();
+
+            // 建立一個 DTO 清單
+            var result = new List<TrialTemplateListDto>();
+
+
+            foreach (var template in templates)
+            {
+                var allTrialTemplates = new TrialTemplateListDto
+                {
+                    Id = template.Id,
+                    TrialTitle = template.TrialTitle,
+                    TrialDescription = template.TrialDescription,
+                    TrialFrequency = template.TrialFrequency,
+                    TrialCategory = template.TrialCategory,
+                    TrialSuitFor = template.TrialSuitFor,
+                    TrialNoSuitFor = template.TrialNoSuitFor,
+                    TrialRule = template.TrialRule,
+                    TrialCaution = template.TrialCaution,
+                    TrialEffect = template.TrialEffect,
+                    StageCount = template.Stages.Count(),
+                    MaxUser = template.MaxUser,
+                    IsAi = template.IsAi,
+                    TrialTemplatePrice = template.TrialTemplatePrice,
+                    CardImagePath = template.CardImagePath,
+                    CardColor = template.CardColor,
+                    Stages = new List<StageInfoDto>()
+
+                };
+
+                // 用 foreach 把 Stage Entity 轉成 StageInfoDto
+                foreach (var stage in template.Stages)
+                {
+                    var stageDto = new StageInfoDto
+                    {
+                        StageIndex = stage.StageIndex,
+                        StageDescription = stage.StageDescription,
+                        StageSampleImagePath = stage.StageSampleImagePath
+                    };
+
+                    allTrialTemplates.Stages.Add(stageDto);
+                }
+
+                result.Add(allTrialTemplates);
+            }
+
+            // 回傳 DTO 清單
+            return Ok(result);
+        }
+
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _context.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+
+}

--- a/GoBetGoal_BackEnd/GoBetGoal_BackEnd.csproj
+++ b/GoBetGoal_BackEnd/GoBetGoal_BackEnd.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Controllers\ChallengeController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\TrialController.cs" />
+    <Compile Include="Controllers\TrialsController.cs" />
     <Compile Include="Controllers\UsersController.cs" />
     <Compile Include="Controllers\ValuesController.cs" />
     <Compile Include="Enums\Method.cs" />
@@ -236,12 +237,14 @@
     <Compile Include="Models\DTOs\RegisterStepOneRequestDto.cs" />
     <Compile Include="Models\DTOs\RegisterStepTwoRequestDto.cs" />
     <Compile Include="Models\DTOs\AuthSuccessResponseDto.cs" />
+    <Compile Include="Models\DTOs\StageInfoDto.cs" />
     <Compile Include="Models\DTOs\SuccessResponseDto.cs" />
     <Compile Include="Models\DTOs\TrialDetailDto.cs" />
     <Compile Include="Models\DTOs\TrialLikeDto.cs" />
     <Compile Include="Models\DTOs\TrialTemplateInfoDto.cs" />
     <Compile Include="Models\DTOs\TrialParticipantDto.cs" />
     <Compile Include="Models\DTOs\TrialStageProgressDto.cs" />
+    <Compile Include="Models\DTOs\TrialTemplateListDto.cs" />
     <Compile Include="Models\DTOs\UpdateAvatarRequestDto.cs" />
     <Compile Include="Models\DTOs\UpdateProfileRequestDto.cs" />
     <Compile Include="Models\DTOs\UserProfileDto.cs" />

--- a/GoBetGoal_BackEnd/Models/DTOs/StageInfoDto.cs
+++ b/GoBetGoal_BackEnd/Models/DTOs/StageInfoDto.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace GoBetGoal_BackEnd.Models.DTOs
+{
+    public class StageInfoDto
+    {
+        public int StageIndex { get; set; }
+
+        public string StageDescription { get; set; }
+
+        public string StageSampleImagePath { get; set; }
+
+    }
+}

--- a/GoBetGoal_BackEnd/Models/DTOs/TrialTemplateListDto.cs
+++ b/GoBetGoal_BackEnd/Models/DTOs/TrialTemplateListDto.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Web;
+
+namespace GoBetGoal_BackEnd.Models.DTOs
+{
+    public class TrialTemplateListDto
+    {
+        public int Id { get; set; }
+
+        public string TrialTitle { get; set; }
+
+        public string TrialDescription { get; set; }
+
+        public int TrialFrequency { get; set; }
+
+        public string TrialCategory { get; set; }
+
+        public string TrialSuitFor { get; set; }
+
+        public string TrialNoSuitFor { get; set; }
+
+        public string TrialRule { get; set; }
+
+        public string TrialCaution { get; set; }
+
+        public string TrialEffect { get; set; }
+
+        public int StageCount { get; set; }
+
+
+        public int MaxUser { get; set; }
+
+        public bool IsAi { get; set; }
+
+        public int TrialTemplatePrice { get; set; }
+
+        //public ProductType ProductType { get; set; }
+
+        public string CardImagePath { get; set; }
+
+        public string CardColor { get; set; }
+
+        public List<StageInfoDto> Stages { get; set; }
+    }
+}


### PR DESCRIPTION
### What this PR does
- Add `TrialsController` to handle trial-related endpoints
- Add DTOs (`StageInfoDto`, `TrialTemplateListDto`) for data transfer
- Implement GET `/api/trials/templates` API to retrieve all trial templates including their stages

